### PR TITLE
[ENH] If SRTM file is not present, try to download it.

### DIFF
--- a/prepare_dtm/lib_mnt.py
+++ b/prepare_dtm/lib_mnt.py
@@ -38,7 +38,6 @@ import tempfile
 from osgeo import gdal, ogr, osr
 import scipy.ndimage as nd
 from os.path import join as pjoin
-import urllib.request
 
 
 # Returns true if coordinate is land
@@ -462,7 +461,11 @@ def fusion_mnt(liste_fic_mnt, liste_fic_eau, liste_centre_eau, rep_mnt, rep_swbd
         ficzip = fic.replace('tif', 'zip')
         if not os.path.exists(rep_mnt + '/' + ficzip):
             print("Need to download the file {0}".format(ficzip))
-            urllib.request.urlretrieve("http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/%s" % ficzip,
+            try:
+                from urllib.request import urlretrieve
+            except ImportError:
+                from urllib import urlretrieve
+            urlretrieve("http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/%s" % ficzip,
                                        rep_mnt + '/' + ficzip)
             if not os.path.exists(rep_mnt + '/' + ficzip):
                 print("Unable to download the file!")

--- a/prepare_dtm/lib_mnt.py
+++ b/prepare_dtm/lib_mnt.py
@@ -38,6 +38,7 @@ import tempfile
 from osgeo import gdal, ogr, osr
 import scipy.ndimage as nd
 from os.path import join as pjoin
+import urllib.request
 
 
 # Returns true if coordinate is land
@@ -458,8 +459,14 @@ def fusion_mnt(liste_fic_mnt, liste_fic_eau, liste_centre_eau, rep_mnt, rep_swbd
         print("FIC: {0}".format(fic))
         print(type(rep_mnt), type(fic))
         print(rep_mnt + '/' + fic)
-        #if not (os.path.exists(rep_mnt + '/' + fic)):
         ficzip = fic.replace('tif', 'zip')
+        if not os.path.exists(rep_mnt + '/' + ficzip):
+            print("Need to download the file {0}".format(ficzip))
+            urllib.request.urlretrieve("http://srtm.csi.cgiar.org/wp-content/uploads/files/srtm_5x5/TIFF/%s" % ficzip,
+                                       rep_mnt + '/' + ficzip)
+            if not os.path.exists(rep_mnt + '/' + ficzip):
+                print("Unable to download the file!")
+                raise RuntimeError("Unable to download the file {0}!".format(ficzip))
         commande = "unzip -o %s/%s -d %s" % (rep_mnt, ficzip, working_dir)
         os.system(commande)
     if len(liste_fic_mnt) > 1:


### PR DESCRIPTION
This PR addresses an issue with prepare_dtm. 
Indeed, with the current version of prepare_dtm, if a SRTM file is not found, the program stops. This is fine when working with one product/tile, but when someone wants to run a script that calls prepare_dtm over a large number of products/tiles it becomes a problem.
The solution I propose is to download the missing SRTM files directly from the CGIAR website. Then, the program stops only if the file can't be download.