### PR TITLE
fix month calculation CAMS downloader

### DIFF
--- a/cams_download/download_CAMS.py
+++ b/cams_download/download_CAMS.py
@@ -355,7 +355,7 @@ else:
 nb_days = (dt2-dt1).days + 1
 print('Number of days =%s' % nb_days)
 
-nb_months = relativedelta(dt1, dt2).months+(dt2.year - dt1.year)*12+1
+nb_months = relativedelta(dt2, dt1).months+(dt2.year - dt1.year)*12+1
 print('Number of months =%s' % nb_months)
 
 # Analysis times


### PR DESCRIPTION
The calculation of months returned a negative value resulting in the CAMS downloader to exit without downloading anything. By applying this small change I was able to post a request for the CAMS data (haven't got any results yet).